### PR TITLE
Modifying global variables to fix compilation with clang

### DIFF
--- a/src/gl_variables.c
+++ b/src/gl_variables.c
@@ -16,24 +16,25 @@
 
 #include "gl_variables.h"
 
-/*constant variables */
-double pi, one_over_4pi, kcal2j, bulk_coef, units_coef, epsw, epsp, eps;
-double bulk_strength, kappa2, kappa;
+/*runtime constant variables */
+//double pi, one_over_4pi, kcal2j, bulk_coef, units_coef;
+double epsw=0., epsp=0., eps=0.;
+double bulk_strength=0., kappa2=0., kappa=0.;
 
 
 /*global scalar variables*/
-int nface, nspt, natm;
+int nface=0, nspt=0, natm=0;
 
 
 /*dynamic allocated variables*/
-int **extr_v; //[3][nspt]
-int **extr_f; //[2][nface]
-int **face;//[3][nface]
+int **extr_v=NULL; //[3][nspt]
+int **extr_f=NULL; //[2][nface]
+int **face=NULL;//[3][nface]
 
-double **vert, **snrm; //[3][nspt];
-double *tr_xyz, *tr_q; //[3]*[nface]
-double *tr_area, *bvct, *xvct; //[nface];
-double *atmrad, *atmchr, *chrpos; //[natm],[3][nface];
+double **vert=NULL, **snrm=NULL; //[3][nspt];
+double *tr_xyz=NULL, *tr_q=NULL; //[3]*[nface]
+double *tr_area=NULL, *bvct=NULL, *xvct=NULL; //[nface];
+double *atmrad=NULL, *atmchr=NULL, *chrpos=NULL; //[natm],[3][nface];
 
 /* GMRes variables */
-double *work, *h;
+double *work=NULL, *h=NULL;

--- a/src/gl_variables.h
+++ b/src/gl_variables.h
@@ -21,8 +21,19 @@
 #include "TABIPBstruct.h"
 
 
-/*constant variables */
-extern double pi, one_over_4pi, kcal2j, bulk_coef, units_coef, epsw, epsp, eps;
+/*consts */
+#define TABIPB_PI            3.14159265358979324
+#define TABIPB_ONE_OVER_4PI  0.079577471545948
+#define TABIPB_KCAL2J        4.184
+#define TABIPB_BULK_COEF     2529.12179861515279 /* constant w/o temp */
+#define TABIPB_UNITS_COEF    1389.3875744 /* 332.0716 * kcal2j */
+#define TABIPB_PARA_TEMP     17459.5591868959 /* units_coef * 4 * pi */
+#define TABIPB_UNITS_PARA    8729.779593448 /* units_coef * 2 * pi */
+
+
+/*runtime constant variables */
+//extern double pi, one_over_4pi, kcal2j, bulk_coef, units_coef;
+extern double epsw, epsp, eps;
 extern double bulk_strength, kappa2, kappa;
 
 

--- a/src/tabipb.c
+++ b/src/tabipb.c
@@ -53,7 +53,6 @@ int tabipb(TABIPBparm *parm, TABIPBvars *vars) {
   extern int output_potential();
 
   /* variables used to compute potential solution */
-  double units_para;
   double *chrptl;
   extern int comp_pot(TABIPBvars *vars, double *chrptl);
 
@@ -80,13 +79,13 @@ int tabipb(TABIPBparm *parm, TABIPBvars *vars) {
   printf("\nSetting up the TABI input...\n");
 
   /***************constant*****************/
-  pi = 3.14159265358979324;
-  one_over_4pi = 0.079577471545948;
-  kcal2j = 4.184;
-  bulk_coef = 2529.12179861515279; /* constant without temperature */
-  units_coef = 332.0716 * kcal2j;
+ // pi = 3.14159265358979324;
+//  one_over_4pi = 0.079577471545948;
+//  kcal2j = 4.184;
+//  bulk_coef = 2529.12179861515279; /* constant without temperature */
+//  units_coef = 332.0716 * kcal2j;
   eps = parm->epsw/parm->epsp;
-  kappa2 = bulk_coef * parm->bulk_strength / parm->epsw / parm->temp;
+  kappa2 = TABIPB_BULK_COEF * parm->bulk_strength / parm->epsw / parm->temp;
   kappa = sqrt(kappa2);
 
   /*read charge coodinates, charges and radius*/
@@ -118,8 +117,6 @@ int tabipb(TABIPBparm *parm, TABIPBvars *vars) {
          &resid, &matvec, psolve, &info);
 
   /* the solvation energy computation */
-  units_para = 2.0 * units_coef * pi;
-
   chrptl = (double *) calloc(nface, sizeof(double));
   comp_pot(vars, chrptl);
 
@@ -149,8 +146,8 @@ int tabipb(TABIPBparm *parm, TABIPBvars *vars) {
     //printf("the couleng is %f,%f\n",couleng,dist);
   }
 
-  soleng = soleng * units_para;
-  couleng = couleng * units_coef;
+  soleng = soleng * TABIPB_UNITS_PARA;
+  couleng = couleng * TABIPB_UNITS_COEF;
   vars->soleng = soleng;
   vars->couleng = couleng;
 
@@ -227,7 +224,7 @@ int comp_source(TABIPBparm *parm, TABIPBvars *vars) {
                         cos_theta = cos_theta * irs;
 
   /* G0 = 1/(4pi*||r_s||_2) */
-                        G0 = one_over_4pi;
+                        G0 = TABIPB_ONE_OVER_4PI;
                         G0 = G0 * irs;
 
   /* G1 = cos_theta*G0/||r_s||_2 */
@@ -286,7 +283,7 @@ int comp_pot(TABIPBvars *vars, double *chrptl) {
                         rs = sqrt(sumrs);
                         irs = 1 / rs;
 
-                        G0 = one_over_4pi;
+                        G0 = TABIPB_ONE_OVER_4PI;
                         G0 = G0 * irs;
                         kappa_rs = kappa * rs;
                         exp_kappa_rs = exp(-kappa_rs);
@@ -316,7 +313,7 @@ int comp_pot(TABIPBvars *vars, double *chrptl) {
 int output_potential(TABIPBvars *vars) {
 
         int i, j, k, jerr, nface_vert;
-        double tot_length, loc_length, aa[3], dot_aa, para_temp, phi_star;
+        double tot_length, loc_length, aa[3], dot_aa, phi_star;
         int **ind_vert;
         double *xtemp, *xyz_temp;
 
@@ -325,7 +322,6 @@ int output_potential(TABIPBvars *vars) {
 
         nface_vert = 15; /* one vertex could have been involved
                             in at most 11 triangles, 15 is safe */
-        para_temp = units_coef * 4 * pi;
 
         if ((xtemp = (double *) calloc(2 * nface, sizeof(double)))  == NULL) {
                 printf("Error in allocating xtemp!\n");
@@ -396,11 +392,11 @@ int output_potential(TABIPBvars *vars) {
         }
 
         for (i = 0; i < 2 * nface; i++)
-                xvct[i] = xvct[i] * para_temp;
+                xvct[i] = xvct[i] * TABIPB_PARA_TEMP;
 
         for (i = 0; i < nspt; i++) {
-                vars->vert_ptl[i] = vars->vert_ptl[i] * para_temp;
-                vars->vert_ptl[i + nspt] = vars->vert_ptl[i + nspt] * para_temp;
+                vars->vert_ptl[i] = vars->vert_ptl[i] * TABIPB_PARA_TEMP;
+                vars->vert_ptl[i + nspt] = vars->vert_ptl[i + nspt] * TABIPB_PARA_TEMP;
         }
 
         if ((vars->xvct = (double *) calloc(2 * nface, sizeof(double))) == NULL) {
@@ -597,7 +593,7 @@ int *matvec_direct(double *alpha, double *x, double *beta, double *y)
                                 sumrs = r_s[0]*r_s[0] + r_s[1]*r_s[1] + r_s[2]*r_s[2];
                                 rs = sqrt(sumrs);
                                 irs = 1 / rs;
-                                G0 = one_over_4pi;
+                                G0 = TABIPB_ONE_OVER_4PI;
                                 G0 = G0 * irs;
                                 kappa_rs = kappa * rs;
                                 exp_kappa_rs = exp(-kappa_rs);

--- a/src/treecode.c
+++ b/src/treecode.c
@@ -24,52 +24,51 @@
 
 
 /* runtime parameters */
-int numpars, order, maxparnode, iflag, forcedim;
-double theta;
-double center[3], r0[3], v0[3];
+static int numpars, order, maxparnode, iflag, forcedim;
+static double theta;
+static double center[3], r0[3], v0[3];
 
 
 /* arrays for coordinates, charge, potential & force */
-double *x, *y, *z, *q;
-double *x_copy, *y_copy, *z_copy, *q_copy;
-double **tforce, **dforce;
-int *orderind, *n_clst;
+static double *x, *y, *z, *q;
+static double *x_copy, *y_copy, *z_copy, *q_copy;
+static double **tforce, **dforce;
+static int *orderind, *n_clst;
 
 
 /* timing variables */
-double timebeg, timeend;
+static double timebeg, timeend;
 
 
 /* local variables */
-double xyzminmax[6];
-double t1, abserr, relerr, adsinf_err, relinf_err;
-double f_inferr[3], f_relinferr[3], t[3];
+static double xyzminmax[6];
+static double t1, abserr, relerr, adsinf_err, relinf_err;
+static double f_inferr[3], f_relinferr[3], t[3];
 
-double ***tchg, ***schg;
-double ****der_cof;
-int kk[16][3];
+static double ***tchg, ***schg;
+static double ****der_cof;
+static int kk[16][3];
 
 
 /* global variables for taylor expansions */
-int torder, torder2, torderlim;
-double *cf, *cf1, *cf2, *cf3;
-double ***a, ***b;
+static int torder, torder2, torderlim;
+static double *cf, *cf1, *cf2, *cf3;
+static double ***a, ***b;
 
 
 /* global variables to track tree levels  */
-int minlevel, maxlevel;
+static int minlevel, maxlevel;
 
 
 /* global variables used when computing potential/force */
-int orderoffset;
-double tarpos[3], tarq[3];
-double tarchr;
+static int orderoffset;
+static double tarpos[3], tarq[3];
+static double tarchr;
 
 
 /* global variables for position and charge storage */
 /* arrays are not copied in this version!! orderarr is till valid*/
 int *orderarr;
-double *xcopy,*ycopy,*zcopy,*qcopy;
 
 
 /* node pointer and node struct declarations */
@@ -85,7 +84,7 @@ typedef struct tnode{
   struct tnode** child;
 }tnode;
 
-tnode* troot;
+static tnode* troot;
 
 
 int treecode_initialization(int main_order,int main_maxparnode,double main_theta) {
@@ -197,7 +196,7 @@ int treecode_initialization(int main_order,int main_maxparnode,double main_theta
     for (j=0;j<order+1;j++){
       for (k=0;k<order+1;k++){
         for (idx=0;idx<16;idx++){
-          der_cof[i][j][k][idx]=der_cof[i][j][k][idx]*one_over_4pi;
+          der_cof[i][j][k][idx]=der_cof[i][j][k][idx] * TABIPB_ONE_OVER_4PI;
         }
       }
     }
@@ -1163,7 +1162,7 @@ int compp_direct_pb(double peng[2],int ibeg,int iend,double *tpoten_old){
     sumrs=r_s[0]*r_s[0]+r_s[1]*r_s[1]+r_s[2]*r_s[2];
     rs=sqrt(sumrs);
     irs=1/rs;
-    G0=one_over_4pi*irs;
+    G0=TABIPB_ONE_OVER_4PI*irs;
     kappa_rs=kappa*rs;
     exp_kappa_rs=exp(-kappa_rs);
     Gk=exp_kappa_rs*G0;


### PR DESCRIPTION
For clang, global variables must be initialized for default behavior to not be treated as belonging to common block. After updating the git submodule reference to this commit, this should handle Electrostatics/apbs#67 